### PR TITLE
Set STOPSIGNAL for SystemD images

### DIFF
--- a/apt_systemd_dockerfile
+++ b/apt_systemd_dockerfile
@@ -27,4 +27,6 @@ RUN rm -f /lib/systemd/system/multi-user.target.wants/* \
 
 VOLUME [ "/sys/fs/cgroup" ]
 
+STOPSIGNAL SIGRTMIN+3
+
 CMD ["/lib/systemd/systemd"]

--- a/yum_systemd_dockerfile
+++ b/yum_systemd_dockerfile
@@ -22,6 +22,8 @@ EXPOSE 22
 
 VOLUME /run /tmp
 
+STOPSIGNAL SIGRTMIN+3
+
 CMD /usr/sbin/init
 
 #CMD ["/bin/bash"]


### PR DESCRIPTION
This commit updates the SystemD Dockerfiles to use `STOPSIGNAL SIGRTMIN+3`.
SystemD responds to the default signal sent by `docker stop`, `SIGTERM`, by
re-executing a new process instead of shutting down. Sending `SIGRTMIN+3`
is the proper way to signal SystemD to shut down.

Ref. https://www.freedesktop.org/software/systemd/man/systemd.html#SIGRTMIN+3
Ref. https://developers.redhat.com/blog/2016/09/13/running-systemd-in-a-non-privileged-container/